### PR TITLE
Re-export EccKeyReadResponse

### DIFF
--- a/tropic01/src/lib.rs
+++ b/tropic01/src/lib.rs
@@ -23,6 +23,7 @@ pub use crate::lt_2::StartupReq;
 pub use crate::lt_2::X509Certificate;
 pub use crate::lt_3::EccCurve;
 pub use crate::lt_3::EccOrigin;
+pub use crate::lt_3::EccKeyReadResponse;
 
 mod crc16;
 mod crypto;


### PR DESCRIPTION
This type is part of the public API via Tropic01::ecc_key_read but is currently not visible.

Fixes: https://github.com/tropicsquare/libtropic-rs/issues/3