### PR TITLE
Use custom types for storing Aes256Gcm keys

### DIFF
--- a/tropic01/src/crypto.rs
+++ b/tropic01/src/crypto.rs
@@ -7,9 +7,8 @@ use hmac::Hmac;
 use hmac::Mac;
 use sha2::Digest;
 use sha2::Sha256;
-use x25519_dalek::PublicKey;
-use x25519_dalek::StaticSecret;
 
+use crate::Aes256GcmKey;
 use crate::L3_FRAME_MAX_SIZE;
 use crate::Nonce;
 
@@ -111,13 +110,13 @@ pub(super) fn sha256_sequence(
 }
 
 pub(super) fn aesgcm_encrypt(
-    key: PublicKey,
+    key: &Aes256GcmKey,
     nonce: &Nonce,
     aad: &[u8],
     buf: &mut ArrayVec<u8, L3_FRAME_MAX_SIZE>,
 ) -> Result<[u8; 16], CryptoError> {
     let nonce = nonce.as_ref().into();
-    let key = Key::<Aes256Gcm>::from_slice(key.as_bytes());
+    let key = Key::<Aes256Gcm>::from_slice(key.as_ref());
     let mut cipher = Aes256Gcm::new(key);
 
     let tag = cipher
@@ -127,14 +126,14 @@ pub(super) fn aesgcm_encrypt(
 }
 
 pub(super) fn aesgcm_decrypt(
-    key: &StaticSecret,
+    key: &Aes256GcmKey,
     nonce: &Nonce,
     aad: &[u8],
     tag: &[u8],
     buf: &mut [u8],
 ) -> Result<(), CryptoError> {
     let nonce = nonce.as_ref().into();
-    let key = Key::<Aes256Gcm>::from_slice(key.as_bytes());
+    let key = Key::<Aes256Gcm>::from_slice(key.as_ref());
     let mut cipher = Aes256Gcm::new(key);
     let tag = tag.into();
     cipher

--- a/tropic01/src/lt_3.rs
+++ b/tropic01/src/lt_3.rs
@@ -178,7 +178,7 @@ impl<SPI: SpiDevice, CS: OutputPin> Tropic01<SPI, CS> {
         let size = U16::try_from(len)
         // Safety: Expect is safe here since l3_buf capacity (L3_FRAME_MAX_SIZE) < U16::MAX.
         .expect("cmd len to be in u16 range");
-        let tag = aesgcm_encrypt(session.encrypt, &session.iv, b"", &mut self.l3_buf)
+        let tag = aesgcm_encrypt(&session.encrypt, &session.iv, b"", &mut self.l3_buf)
             .map_err(Error::Encryption)?;
 
         let cmd = EncryptedL3CommandPacket {


### PR DESCRIPTION
Previously, the PublicKey and StaticSecret types from x25519-dalek were used for this, probably because they implement Zeroize and aes_gcm::Key does not. This patch introduces a custom wrapper type to remove this dependency.