### PR TITLE
drop nom and nom-derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,5 +140,3 @@ zero_sized_map_values = "warn"
 broken_intra_doc_links = "warn"
 private_doc_tests = "warn"
 
-[patch.crates-io]
-nom-derive = { git = "https://github.com/rust-bakery/nom-derive.git", rev = "f68f464f50f7162483355e61a50ec2a7dae8044f" }

--- a/tropic01/Cargo.toml
+++ b/tropic01/Cargo.toml
@@ -27,7 +27,6 @@ dummy-pin = { version = "1.0.0", default-features = false }
 embedded-hal = { version = "1", default-features = false }
 hmac = { version = "0.12", default-features = false }
 nom = { version = "8", default-features = false }
-nom-derive = { version = "0.11", default-features = false }
 packed_struct = { version = "0.10.1", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 x25519-dalek = { version = "2", default-features = false, features = [

--- a/tropic01/Cargo.toml
+++ b/tropic01/Cargo.toml
@@ -22,6 +22,7 @@ derive_more = { version = "2", default-features = false, features = [
   "display",
   "error",
   "from",
+  "try_from",
 ] }
 dummy-pin = { version = "1.0.0", default-features = false }
 embedded-hal = { version = "1", default-features = false }

--- a/tropic01/Cargo.toml
+++ b/tropic01/Cargo.toml
@@ -26,7 +26,6 @@ derive_more = { version = "2", default-features = false, features = [
 dummy-pin = { version = "1.0.0", default-features = false }
 embedded-hal = { version = "1", default-features = false }
 hmac = { version = "0.12", default-features = false }
-nom = { version = "8", default-features = false }
 packed_struct = { version = "0.10.1", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 x25519-dalek = { version = "2", default-features = false, features = [

--- a/tropic01/src/lib.rs
+++ b/tropic01/src/lib.rs
@@ -8,7 +8,6 @@ use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::ErrorType as SpiErrorType;
 use embedded_hal::spi::SpiDevice;
 use nom::Needed;
-use nom_derive::Parse;
 use packed_struct::PackingError;
 use packed_struct::derive::PackedStruct;
 use zerocopy::IntoBytes;
@@ -143,7 +142,7 @@ impl From<nom::Err<ParsingError>> for ParsingError {
     }
 }
 
-/// Convenience trait to auto-implement nom parsing for all T that derive `Nom`.
+/// Trait for parsing types from byte slices using nom parsers.
 trait FromBytes<'a>
 where
     Self: Sized,
@@ -151,10 +150,12 @@ where
     fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError>;
 }
 
-impl<'a, T: Parse<&'a [u8]>> FromBytes<'a> for T {
-    fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
-        let (_, res) = T::parse(slice).map_err(|e| e.map(|e| ParsingError::Error(e.code)))?;
-        Ok(res)
+/// Convert a nom error into a [ParsingError].
+pub(crate) const fn nom_err(e: nom::Err<nom::error::Error<&[u8]>>) -> ParsingError {
+    match e {
+        nom::Err::Error(e) => ParsingError::Error(e.code),
+        nom::Err::Incomplete(n) => ParsingError::Needed(n),
+        nom::Err::Failure(e) => ParsingError::Error(e.code),
     }
 }
 

--- a/tropic01/src/lib.rs
+++ b/tropic01/src/lib.rs
@@ -7,7 +7,6 @@ use embedded_hal::digital::ErrorType as GpioErrorType;
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::ErrorType as SpiErrorType;
 use embedded_hal::spi::SpiDevice;
-use nom::Needed;
 use packed_struct::PackingError;
 use packed_struct::derive::PackedStruct;
 use zerocopy::IntoBytes;
@@ -126,23 +125,13 @@ struct ChipStatus {
 /// Represents all kinds of parsing errors.
 #[derive(Debug, derive_more::Display, derive_more::Error)]
 pub enum ParsingError {
-    #[display("Parsing failed: {_0:?}")]
-    Error(#[error(not(source))] nom::error::ErrorKind),
-    #[display("Parsing failed, needs more bytes: {_0:?}")]
-    Needed(#[error(not(source))] Needed),
+    #[display("Parsing failed: not enough bytes")]
+    InsufficientData,
+    #[display("Parsing failed: invalid data")]
+    InvalidData,
 }
 
-impl From<nom::Err<ParsingError>> for ParsingError {
-    fn from(other: nom::Err<ParsingError>) -> Self {
-        match other {
-            nom::Err::Error(e) => e,
-            nom::Err::Incomplete(e) => ParsingError::Needed(e),
-            nom::Err::Failure(e) => e,
-        }
-    }
-}
-
-/// Trait for parsing types from byte slices using nom parsers.
+/// Trait for parsing types from byte slices.
 trait FromBytes<'a>
 where
     Self: Sized,
@@ -150,13 +139,39 @@ where
     fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError>;
 }
 
-/// Convert a nom error into a [ParsingError].
-pub(crate) const fn nom_err(e: nom::Err<nom::error::Error<&[u8]>>) -> ParsingError {
-    match e {
-        nom::Err::Error(e) => ParsingError::Error(e.code),
-        nom::Err::Incomplete(n) => ParsingError::Needed(n),
-        nom::Err::Failure(e) => ParsingError::Error(e.code),
+/// Read a single byte from the front of the slice.
+pub(crate) const fn take_u8(slice: &[u8]) -> Result<(&[u8], u8), ParsingError> {
+    match slice.split_first() {
+        Some((&b, rest)) => Ok((rest, b)),
+        None => Err(ParsingError::InsufficientData),
     }
+}
+
+/// Read a little-endian u16 from the front of the slice.
+pub(crate) const fn take_le_u16(slice: &[u8]) -> Result<(&[u8], u16), ParsingError> {
+    if slice.len() < 2 {
+        return Err(ParsingError::InsufficientData);
+    }
+    let (bytes, rest) = slice.split_at(2);
+    Ok((rest, u16::from_le_bytes([bytes[0], bytes[1]])))
+}
+
+/// Read a big-endian u16 from the front of the slice.
+pub(crate) const fn take_be_u16(slice: &[u8]) -> Result<(&[u8], u16), ParsingError> {
+    if slice.len() < 2 {
+        return Err(ParsingError::InsufficientData);
+    }
+    let (bytes, rest) = slice.split_at(2);
+    Ok((rest, u16::from_be_bytes([bytes[0], bytes[1]])))
+}
+
+/// Take `n` bytes from the front of the slice.
+pub(crate) const fn take(slice: &[u8], n: usize) -> Result<(&[u8], &[u8]), ParsingError> {
+    if slice.len() < n {
+        return Err(ParsingError::InsufficientData);
+    }
+    let (taken, rest) = slice.split_at(n);
+    Ok((rest, taken))
 }
 
 /// Any type of error which may occur while interacting with the device

--- a/tropic01/src/lib.rs
+++ b/tropic01/src/lib.rs
@@ -131,6 +131,12 @@ pub enum ParsingError {
     InvalidData,
 }
 
+impl<T: core::fmt::Debug> From<derive_more::TryFromReprError<T>> for ParsingError {
+    fn from(_: derive_more::TryFromReprError<T>) -> Self {
+        Self::InvalidData
+    }
+}
+
 /// Trait for parsing types from byte slices.
 trait FromBytes<'a>
 where

--- a/tropic01/src/lt_2.rs
+++ b/tropic01/src/lt_2.rs
@@ -56,8 +56,18 @@ enum L2RequestId {
 }
 
 /// Represents all possible response status codes the chip may return.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::Display, derive_more::Error)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    derive_more::TryFrom,
+    derive_more::Display,
+    derive_more::Error,
+)]
 #[repr(u8)]
+#[try_from(repr)]
 pub enum ResponseStatus {
     ReqOk = 0x01,
     ResOk = 0x02,
@@ -89,30 +99,10 @@ pub enum ResponseStatus {
     NoResp = 0xff,
 }
 
-impl ResponseStatus {
-    const fn from_u8(b: u8) -> Result<Self, ParsingError> {
-        match b {
-            0x01 => Ok(Self::ReqOk),
-            0x02 => Ok(Self::ResOk),
-            0x03 => Ok(Self::ReqCont),
-            0x04 => Ok(Self::ResCont),
-            0x78 => Ok(Self::RespDisabled),
-            0x79 => Ok(Self::HskErr),
-            0x7a => Ok(Self::NoSession),
-            0x7b => Ok(Self::TagErr),
-            0x7c => Ok(Self::CrcErr),
-            0x7e => Ok(Self::UnknownReq),
-            0x7f => Ok(Self::GenErr),
-            0xff => Ok(Self::NoResp),
-            _ => Err(ParsingError::InvalidData),
-        }
-    }
-}
-
 impl<'a> FromBytes<'a> for ResponseStatus {
     fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
         let (_, b) = take_u8(slice)?;
-        Self::from_u8(b)
+        Ok(Self::try_from(b)?)
     }
 }
 #[derive(Clone, Debug, IntoBytes, Unaligned)]
@@ -157,7 +147,7 @@ impl<'a> FromBytes<'a> for L2ResponseFrame<'a> {
     fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
         let (rest, chip_status) = take_u8(slice)?;
         let (rest, status_byte) = take_u8(rest)?;
-        let resp_status = ResponseStatus::from_u8(status_byte)?;
+        let resp_status = ResponseStatus::try_from(status_byte)?;
         let (rest, len) = take_u8(rest)?;
         let (rest, resp_data) = take(rest, len as usize)?;
         let (_, crc) = take_be_u16(rest)?;

--- a/tropic01/src/lt_2.rs
+++ b/tropic01/src/lt_2.rs
@@ -16,7 +16,9 @@ use crate::Aes256GcmKey;
 use crate::FromBytes;
 use crate::L2_CHUNK_MAX_DATA_SIZE;
 use crate::ParsingError;
-use crate::nom_err;
+use crate::take;
+use crate::take_be_u16;
+use crate::take_u8;
 use crate::L2_CMD_REQ_LEN;
 use crate::L3_CMD_DATA_SIZE_MAX;
 use crate::L3_CMD_SIZE_SIZE;
@@ -102,14 +104,14 @@ impl ResponseStatus {
             0x7e => Ok(Self::UnknownReq),
             0x7f => Ok(Self::GenErr),
             0xff => Ok(Self::NoResp),
-            _ => Err(ParsingError::Error(nom::error::ErrorKind::MapOpt)),
+            _ => Err(ParsingError::InvalidData),
         }
     }
 }
 
 impl<'a> FromBytes<'a> for ResponseStatus {
     fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
-        let (_, b) = nom::number::complete::be_u8(slice).map_err(nom_err)?;
+        let (_, b) = take_u8(slice)?;
         Self::from_u8(b)
     }
 }
@@ -153,12 +155,12 @@ struct L2ResponseFrame<'a> {
 
 impl<'a> FromBytes<'a> for L2ResponseFrame<'a> {
     fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
-        let (rest, chip_status) = nom::number::complete::be_u8(slice).map_err(nom_err)?;
-        let (rest, status_byte) = nom::number::complete::be_u8(rest).map_err(nom_err)?;
+        let (rest, chip_status) = take_u8(slice)?;
+        let (rest, status_byte) = take_u8(rest)?;
         let resp_status = ResponseStatus::from_u8(status_byte)?;
-        let (rest, len) = nom::number::complete::be_u8(rest).map_err(nom_err)?;
-        let (rest, resp_data) = nom::bytes::complete::take(len as usize)(rest).map_err(nom_err)?;
-        let (_, crc) = nom::number::complete::be_u16(rest).map_err(nom_err)?;
+        let (rest, len) = take_u8(rest)?;
+        let (rest, resp_data) = take(rest, len as usize)?;
+        let (_, crc) = take_be_u16(rest)?;
         Ok(Self {
             _chip_status: chip_status,
             resp_status,
@@ -259,8 +261,8 @@ struct HandShakeResponse<'a> {
 
 impl<'a> FromBytes<'a> for HandShakeResponse<'a> {
     fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
-        let (rest, etpub) = nom::bytes::complete::take(32usize)(slice).map_err(nom_err)?;
-        let (_, ttauth) = nom::bytes::complete::take(16usize)(rest).map_err(nom_err)?;
+        let (rest, etpub) = take(slice, 32)?;
+        let (_, ttauth) = take(rest, 16)?;
         Ok(Self { etpub, ttauth })
     }
 }

--- a/tropic01/src/lt_2.rs
+++ b/tropic01/src/lt_2.rs
@@ -15,10 +15,6 @@ use super::Tropic01;
 use crate::Aes256GcmKey;
 use crate::FromBytes;
 use crate::L2_CHUNK_MAX_DATA_SIZE;
-use crate::ParsingError;
-use crate::take;
-use crate::take_be_u16;
-use crate::take_u8;
 use crate::L2_CMD_REQ_LEN;
 use crate::L3_CMD_DATA_SIZE_MAX;
 use crate::L3_CMD_SIZE_SIZE;
@@ -26,6 +22,7 @@ use crate::L3_FRAME_MAX_SIZE;
 use crate::L3_RES_SIZE_SIZE;
 use crate::L3_TAG_SIZE;
 use crate::Nonce;
+use crate::ParsingError;
 use crate::crc16::Crc16;
 use crate::crypto::CryptoError;
 use crate::crypto::X25519;
@@ -37,6 +34,9 @@ use crate::lt_1::l1_read;
 use crate::lt_1::l1_write;
 use crate::lt_3::EncryptedL3CommandPacket;
 use crate::lt_3::L3ResultPacket;
+use crate::take;
+use crate::take_be_u16;
+use crate::take_u8;
 
 const L2_GET_INFO_REQ_CERT_SIZE: usize = 512;
 /// Protocol Name

--- a/tropic01/src/lt_2.rs
+++ b/tropic01/src/lt_2.rs
@@ -5,7 +5,6 @@ use embedded_hal::digital::ErrorType as GpioErrorType;
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::ErrorType as SpiErrorType;
 use embedded_hal::spi::SpiDevice;
-use nom_derive::Nom;
 use zerocopy::BE;
 use zerocopy::IntoBytes;
 use zerocopy::U16;
@@ -16,6 +15,8 @@ use super::Tropic01;
 use crate::Aes256GcmKey;
 use crate::FromBytes;
 use crate::L2_CHUNK_MAX_DATA_SIZE;
+use crate::ParsingError;
+use crate::nom_err;
 use crate::L2_CMD_REQ_LEN;
 use crate::L3_CMD_DATA_SIZE_MAX;
 use crate::L3_CMD_SIZE_SIZE;
@@ -53,7 +54,7 @@ enum L2RequestId {
 }
 
 /// Represents all possible response status codes the chip may return.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Nom, derive_more::Display, derive_more::Error)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::Display, derive_more::Error)]
 #[repr(u8)]
 pub enum ResponseStatus {
     ReqOk = 0x01,
@@ -85,6 +86,33 @@ pub enum ResponseStatus {
     #[display("No L2 response frame available")]
     NoResp = 0xff,
 }
+
+impl ResponseStatus {
+    const fn from_u8(b: u8) -> Result<Self, ParsingError> {
+        match b {
+            0x01 => Ok(Self::ReqOk),
+            0x02 => Ok(Self::ResOk),
+            0x03 => Ok(Self::ReqCont),
+            0x04 => Ok(Self::ResCont),
+            0x78 => Ok(Self::RespDisabled),
+            0x79 => Ok(Self::HskErr),
+            0x7a => Ok(Self::NoSession),
+            0x7b => Ok(Self::TagErr),
+            0x7c => Ok(Self::CrcErr),
+            0x7e => Ok(Self::UnknownReq),
+            0x7f => Ok(Self::GenErr),
+            0xff => Ok(Self::NoResp),
+            _ => Err(ParsingError::Error(nom::error::ErrorKind::MapOpt)),
+        }
+    }
+}
+
+impl<'a> FromBytes<'a> for ResponseStatus {
+    fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
+        let (_, b) = nom::number::complete::be_u8(slice).map_err(nom_err)?;
+        Self::from_u8(b)
+    }
+}
 #[derive(Clone, Debug, IntoBytes, Unaligned)]
 #[repr(C)]
 pub(super) struct L2RequestFrame<'a> {
@@ -114,15 +142,31 @@ impl<'a> L2RequestFrame<'a> {
     }
 }
 
-#[derive(Debug, Nom)]
+#[derive(Debug)]
 struct L2ResponseFrame<'a> {
     _chip_status: u8,
     resp_status: ResponseStatus,
     len: u8,
-    #[nom(Take = "len")]
     resp_data: &'a [u8],
-    #[nom(BigEndian)]
     crc: u16,
+}
+
+impl<'a> FromBytes<'a> for L2ResponseFrame<'a> {
+    fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
+        let (rest, chip_status) = nom::number::complete::be_u8(slice).map_err(nom_err)?;
+        let (rest, status_byte) = nom::number::complete::be_u8(rest).map_err(nom_err)?;
+        let resp_status = ResponseStatus::from_u8(status_byte)?;
+        let (rest, len) = nom::number::complete::be_u8(rest).map_err(nom_err)?;
+        let (rest, resp_data) = nom::bytes::complete::take(len as usize)(rest).map_err(nom_err)?;
+        let (_, crc) = nom::number::complete::be_u16(rest).map_err(nom_err)?;
+        Ok(Self {
+            _chip_status: chip_status,
+            resp_status,
+            len,
+            resp_data,
+            crc,
+        })
+    }
 }
 
 impl<'a> L2ResponseFrame<'a> {
@@ -207,12 +251,18 @@ pub enum SleepReq {
     DeepSleep = 0x0a,
 }
 
-#[derive(Debug, Nom)]
+#[derive(Debug)]
 struct HandShakeResponse<'a> {
-    #[nom(Take = "32")]
     etpub: &'a [u8],
-    #[nom(Take = "16")]
     ttauth: &'a [u8],
+}
+
+impl<'a> FromBytes<'a> for HandShakeResponse<'a> {
+    fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
+        let (rest, etpub) = nom::bytes::complete::take(32usize)(slice).map_err(nom_err)?;
+        let (_, ttauth) = nom::bytes::complete::take(16usize)(rest).map_err(nom_err)?;
+        Ok(Self { etpub, ttauth })
+    }
 }
 
 impl<SPI: SpiDevice, CS: OutputPin> Tropic01<SPI, CS> {

--- a/tropic01/src/lt_3.rs
+++ b/tropic01/src/lt_3.rs
@@ -2,12 +2,13 @@ use embedded_hal::digital::ErrorType as GpioErrorType;
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::ErrorType as SpiErrorType;
 use embedded_hal::spi::SpiDevice;
-use nom_derive::Nom;
 use zerocopy::IntoBytes;
 use zerocopy::little_endian::U16;
 
 use crate::Error;
 use crate::FromBytes;
+use crate::ParsingError;
+use crate::nom_err;
 use crate::L3_CMD_DATA_SIZE_MAX;
 use crate::L3_RES_SIZE_SIZE;
 use crate::L3_TAG_SIZE;
@@ -70,11 +71,28 @@ enum L3CmdId {
 }
 
 /// Represents all kinds of curves the chip supports.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Nom)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum EccCurve {
     P256 = 0x01,
     Ed25519 = 0x02,
+}
+
+impl EccCurve {
+    const fn from_u8(b: u8) -> Result<Self, ParsingError> {
+        match b {
+            0x01 => Ok(Self::P256),
+            0x02 => Ok(Self::Ed25519),
+            _ => Err(ParsingError::Error(nom::error::ErrorKind::MapOpt)),
+        }
+    }
+}
+
+impl<'a> FromBytes<'a> for EccCurve {
+    fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
+        let (_, b) = nom::number::complete::be_u8(slice).map_err(nom_err)?;
+        Self::from_u8(b)
+    }
 }
 
 /// Monotonic counter index (0-15).
@@ -111,27 +129,48 @@ impl EccCurve {
     }
 }
 
-#[derive(Debug, Nom)]
+#[derive(Debug)]
 pub(super) struct L3ResultPacket<'a> {
-    #[nom(LittleEndian)]
     _size: u16,
-    #[nom(Take = "_size")]
     _ciphertext: &'a [u8],
     _tag: [u8; 16],
+}
+
+impl<'a> FromBytes<'a> for L3ResultPacket<'a> {
+    fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
+        let (rest, size) = nom::number::complete::le_u16(slice).map_err(nom_err)?;
+        let (rest, ciphertext) = nom::bytes::complete::take(size as usize)(rest).map_err(nom_err)?;
+        let (_, tag_slice) = nom::bytes::complete::take(16usize)(rest).map_err(nom_err)?;
+        let tag: [u8; 16] = tag_slice
+            .try_into()
+            // Safety: take(16) guarantees exactly 16 bytes
+            .expect("tag to be 16 bytes");
+        Ok(Self {
+            _size: size,
+            _ciphertext: ciphertext,
+            _tag: tag,
+        })
+    }
 }
 
 /// Decrypted result data.
 ///
 /// This is the decrypted content of [L3ResultPacket]s `ciphertext` field.
-#[derive(Debug, Nom)]
-#[nom(Exact)]
+#[derive(Debug)]
 struct L3ResultData<'a> {
     result: L3ResultStatus,
-    #[nom(Take = "i.len()")]
     data: &'a [u8],
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Nom, derive_more::Display, derive_more::Error)]
+impl<'a> FromBytes<'a> for L3ResultData<'a> {
+    fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
+        let (rest, b) = nom::number::complete::be_u8(slice).map_err(nom_err)?;
+        let result = L3ResultStatus::from_u8(b)?;
+        Ok(Self { result, data: rest })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::Display, derive_more::Error)]
 #[repr(u8)]
 enum L3ResultStatus {
     Ok = 0xc3,
@@ -141,8 +180,21 @@ enum L3ResultStatus {
     InvalidKey = 0x12,
 }
 
+impl L3ResultStatus {
+    const fn from_u8(b: u8) -> Result<Self, ParsingError> {
+        match b {
+            0xc3 => Ok(Self::Ok),
+            0x3c => Ok(Self::Fail),
+            0x01 => Ok(Self::Unauthorized),
+            0x02 => Ok(Self::InvalidCmd),
+            0x12 => Ok(Self::InvalidKey),
+            _ => Err(ParsingError::Error(nom::error::ErrorKind::MapOpt)),
+        }
+    }
+}
+
 /// Represents all kinds of origins the chip supports.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Nom)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum EccOrigin {
     /// Key originated from the [Tropic01::ecc_key_generate] method.
@@ -151,14 +203,39 @@ pub enum EccOrigin {
     KeyStore = 0x02,
 }
 
-#[derive(Debug, Clone, Nom)]
+impl EccOrigin {
+    const fn from_u8(b: u8) -> Result<Self, ParsingError> {
+        match b {
+            0x01 => Ok(Self::KeyGenerate),
+            0x02 => Ok(Self::KeyStore),
+            _ => Err(ParsingError::Error(nom::error::ErrorKind::MapOpt)),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct EccKeyReadResponse<'a> {
     curve: EccCurve,
     origin: EccOrigin,
     /// The public key. For P-256 curves, this is the uncompressed x + y
     /// coordinates.
-    #[nom(Take = "curve.key_len()", SkipBefore(13))]
     pub_key: &'a [u8],
+}
+
+impl<'a> FromBytes<'a> for EccKeyReadResponse<'a> {
+    fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
+        let (rest, curve_byte) = nom::number::complete::be_u8(slice).map_err(nom_err)?;
+        let curve = EccCurve::from_u8(curve_byte)?;
+        let (rest, origin_byte) = nom::number::complete::be_u8(rest).map_err(nom_err)?;
+        let origin = EccOrigin::from_u8(origin_byte)?;
+        let (rest, _) = nom::bytes::complete::take(13usize)(rest).map_err(nom_err)?;
+        let (_, pub_key) = nom::bytes::complete::take(curve.key_len())(rest).map_err(nom_err)?;
+        Ok(Self {
+            curve,
+            origin,
+            pub_key,
+        })
+    }
 }
 
 impl<'a> EccKeyReadResponse<'a> {
@@ -178,10 +255,17 @@ impl<'a> EccKeyReadResponse<'a> {
     }
 }
 
-#[derive(Debug, Clone, Nom)]
+#[derive(Debug, Clone)]
 struct SignResponse<'a> {
-    #[nom(SkipBefore(15), Take(64))]
     signature: &'a [u8],
+}
+
+impl<'a> FromBytes<'a> for SignResponse<'a> {
+    fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
+        let (rest, _) = nom::bytes::complete::take(15usize)(slice).map_err(nom_err)?;
+        let (_, signature) = nom::bytes::complete::take(64usize)(rest).map_err(nom_err)?;
+        Ok(Self { signature })
+    }
 }
 
 impl<SPI: SpiDevice, CS: OutputPin> Tropic01<SPI, CS> {

--- a/tropic01/src/lt_3.rs
+++ b/tropic01/src/lt_3.rs
@@ -8,7 +8,9 @@ use zerocopy::little_endian::U16;
 use crate::Error;
 use crate::FromBytes;
 use crate::ParsingError;
-use crate::nom_err;
+use crate::take;
+use crate::take_le_u16;
+use crate::take_u8;
 use crate::L3_CMD_DATA_SIZE_MAX;
 use crate::L3_RES_SIZE_SIZE;
 use crate::L3_TAG_SIZE;
@@ -83,14 +85,14 @@ impl EccCurve {
         match b {
             0x01 => Ok(Self::P256),
             0x02 => Ok(Self::Ed25519),
-            _ => Err(ParsingError::Error(nom::error::ErrorKind::MapOpt)),
+            _ => Err(ParsingError::InvalidData),
         }
     }
 }
 
 impl<'a> FromBytes<'a> for EccCurve {
     fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
-        let (_, b) = nom::number::complete::be_u8(slice).map_err(nom_err)?;
+        let (_, b) = take_u8(slice)?;
         Self::from_u8(b)
     }
 }
@@ -138,9 +140,9 @@ pub(super) struct L3ResultPacket<'a> {
 
 impl<'a> FromBytes<'a> for L3ResultPacket<'a> {
     fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
-        let (rest, size) = nom::number::complete::le_u16(slice).map_err(nom_err)?;
-        let (rest, ciphertext) = nom::bytes::complete::take(size as usize)(rest).map_err(nom_err)?;
-        let (_, tag_slice) = nom::bytes::complete::take(16usize)(rest).map_err(nom_err)?;
+        let (rest, size) = take_le_u16(slice)?;
+        let (rest, ciphertext) = take(rest, size as usize)?;
+        let (_, tag_slice) = take(rest, 16)?;
         let tag: [u8; 16] = tag_slice
             .try_into()
             // Safety: take(16) guarantees exactly 16 bytes
@@ -164,7 +166,7 @@ struct L3ResultData<'a> {
 
 impl<'a> FromBytes<'a> for L3ResultData<'a> {
     fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
-        let (rest, b) = nom::number::complete::be_u8(slice).map_err(nom_err)?;
+        let (rest, b) = take_u8(slice)?;
         let result = L3ResultStatus::from_u8(b)?;
         Ok(Self { result, data: rest })
     }
@@ -188,7 +190,7 @@ impl L3ResultStatus {
             0x01 => Ok(Self::Unauthorized),
             0x02 => Ok(Self::InvalidCmd),
             0x12 => Ok(Self::InvalidKey),
-            _ => Err(ParsingError::Error(nom::error::ErrorKind::MapOpt)),
+            _ => Err(ParsingError::InvalidData),
         }
     }
 }
@@ -208,7 +210,7 @@ impl EccOrigin {
         match b {
             0x01 => Ok(Self::KeyGenerate),
             0x02 => Ok(Self::KeyStore),
-            _ => Err(ParsingError::Error(nom::error::ErrorKind::MapOpt)),
+            _ => Err(ParsingError::InvalidData),
         }
     }
 }
@@ -224,12 +226,12 @@ pub struct EccKeyReadResponse<'a> {
 
 impl<'a> FromBytes<'a> for EccKeyReadResponse<'a> {
     fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
-        let (rest, curve_byte) = nom::number::complete::be_u8(slice).map_err(nom_err)?;
+        let (rest, curve_byte) = take_u8(slice)?;
         let curve = EccCurve::from_u8(curve_byte)?;
-        let (rest, origin_byte) = nom::number::complete::be_u8(rest).map_err(nom_err)?;
+        let (rest, origin_byte) = take_u8(rest)?;
         let origin = EccOrigin::from_u8(origin_byte)?;
-        let (rest, _) = nom::bytes::complete::take(13usize)(rest).map_err(nom_err)?;
-        let (_, pub_key) = nom::bytes::complete::take(curve.key_len())(rest).map_err(nom_err)?;
+        let (rest, _) = take(rest, 13)?;
+        let (_, pub_key) = take(rest, curve.key_len())?;
         Ok(Self {
             curve,
             origin,
@@ -262,8 +264,8 @@ struct SignResponse<'a> {
 
 impl<'a> FromBytes<'a> for SignResponse<'a> {
     fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
-        let (rest, _) = nom::bytes::complete::take(15usize)(slice).map_err(nom_err)?;
-        let (_, signature) = nom::bytes::complete::take(64usize)(rest).map_err(nom_err)?;
+        let (rest, _) = take(slice, 15)?;
+        let (_, signature) = take(rest, 64)?;
         Ok(Self { signature })
     }
 }

--- a/tropic01/src/lt_3.rs
+++ b/tropic01/src/lt_3.rs
@@ -73,27 +73,18 @@ enum L3CmdId {
 }
 
 /// Represents all kinds of curves the chip supports.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::TryFrom)]
 #[repr(u8)]
+#[try_from(repr)]
 pub enum EccCurve {
     P256 = 0x01,
     Ed25519 = 0x02,
 }
 
-impl EccCurve {
-    const fn from_u8(b: u8) -> Result<Self, ParsingError> {
-        match b {
-            0x01 => Ok(Self::P256),
-            0x02 => Ok(Self::Ed25519),
-            _ => Err(ParsingError::InvalidData),
-        }
-    }
-}
-
 impl<'a> FromBytes<'a> for EccCurve {
     fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
         let (_, b) = take_u8(slice)?;
-        Self::from_u8(b)
+        Ok(Self::try_from(b)?)
     }
 }
 
@@ -167,13 +158,23 @@ struct L3ResultData<'a> {
 impl<'a> FromBytes<'a> for L3ResultData<'a> {
     fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
         let (rest, b) = take_u8(slice)?;
-        let result = L3ResultStatus::from_u8(b)?;
+        let result = L3ResultStatus::try_from(b)?;
         Ok(Self { result, data: rest })
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::Display, derive_more::Error)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    derive_more::TryFrom,
+    derive_more::Display,
+    derive_more::Error,
+)]
 #[repr(u8)]
+#[try_from(repr)]
 enum L3ResultStatus {
     Ok = 0xc3,
     Fail = 0x3c,
@@ -182,37 +183,15 @@ enum L3ResultStatus {
     InvalidKey = 0x12,
 }
 
-impl L3ResultStatus {
-    const fn from_u8(b: u8) -> Result<Self, ParsingError> {
-        match b {
-            0xc3 => Ok(Self::Ok),
-            0x3c => Ok(Self::Fail),
-            0x01 => Ok(Self::Unauthorized),
-            0x02 => Ok(Self::InvalidCmd),
-            0x12 => Ok(Self::InvalidKey),
-            _ => Err(ParsingError::InvalidData),
-        }
-    }
-}
-
 /// Represents all kinds of origins the chip supports.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::TryFrom)]
 #[repr(u8)]
+#[try_from(repr)]
 pub enum EccOrigin {
     /// Key originated from the [Tropic01::ecc_key_generate] method.
     KeyGenerate = 0x01,
     /// Key originated from the [Tropic01::ecc_key_read] method.
     KeyStore = 0x02,
-}
-
-impl EccOrigin {
-    const fn from_u8(b: u8) -> Result<Self, ParsingError> {
-        match b {
-            0x01 => Ok(Self::KeyGenerate),
-            0x02 => Ok(Self::KeyStore),
-            _ => Err(ParsingError::InvalidData),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -227,9 +206,9 @@ pub struct EccKeyReadResponse<'a> {
 impl<'a> FromBytes<'a> for EccKeyReadResponse<'a> {
     fn from_bytes(slice: &'a [u8]) -> Result<Self, ParsingError> {
         let (rest, curve_byte) = take_u8(slice)?;
-        let curve = EccCurve::from_u8(curve_byte)?;
+        let curve = EccCurve::try_from(curve_byte)?;
         let (rest, origin_byte) = take_u8(rest)?;
-        let origin = EccOrigin::from_u8(origin_byte)?;
+        let origin = EccOrigin::try_from(origin_byte)?;
         let (rest, _) = take(rest, 13)?;
         let (_, pub_key) = take(rest, curve.key_len())?;
         Ok(Self {

--- a/tropic01/src/lt_3.rs
+++ b/tropic01/src/lt_3.rs
@@ -7,18 +7,18 @@ use zerocopy::little_endian::U16;
 
 use crate::Error;
 use crate::FromBytes;
-use crate::ParsingError;
-use crate::take;
-use crate::take_le_u16;
-use crate::take_u8;
 use crate::L3_CMD_DATA_SIZE_MAX;
 use crate::L3_RES_SIZE_SIZE;
 use crate::L3_TAG_SIZE;
+use crate::ParsingError;
 use crate::Tropic01;
 use crate::crypto::aesgcm_decrypt;
 use crate::crypto::aesgcm_encrypt;
 use crate::lt_2::l2_receive_encrypted_cmd;
 use crate::lt_2::l2_send_encrypted_cmd;
+use crate::take;
+use crate::take_le_u16;
+use crate::take_u8;
 
 #[derive(Clone, Debug)]
 struct DecryptedL3CommandPacket<'a> {


### PR DESCRIPTION
since it seems that nom-derive will not publish a new release soon (see stalled https://github.com/rust-bakery/nom-derive/issues/76), i have decided to try removing nom-derive and nom

result is in this PR

can you have a look @robin-nitrokey 

`cargo clippy` and `cargo test` work